### PR TITLE
Add live cursor example

### DIFF
--- a/server/connection.go
+++ b/server/connection.go
@@ -48,8 +48,8 @@ func (c *connection) receiver(s *Server) {
 		}
 
 		xy := struct {
-			X int `json:"x"`
-			Y int `json:"y"`
+			X  int    `json:"x"`
+			Y  int    `json:"y"`
 			Id string `json:"id"`
 		}{}
 		err = json.Unmarshal(data, &xy)

--- a/server/connection.go
+++ b/server/connection.go
@@ -60,7 +60,7 @@ func (c *connection) receiver(s *Server) {
 		s.broadcast(morphData{
 			Type: "morph_data",
 			Id:   "cursor_" + xy.Id,
-			Html: fmt.Sprintf("<div id=\"cursor_%s\" class=\"cursor\" style=\"--x: %d; --y: %d;\"> </div>", xy.Id, xy.X, xy.Y),
+			Html: fmt.Sprintf("<div id=\"cursor_%s\" class=\"cursor\" style=\"--x: %d; --y: %d;\">%[1]s</div>", xy.Id, xy.X, xy.Y),
 		})
 	}
 }

--- a/server/connection.go
+++ b/server/connection.go
@@ -14,10 +14,12 @@ type connection struct {
 }
 
 func newConnection(id int, conn net.Conn) *connection {
-	return &connection{
+	c := &connection{
 		id:   id,
 		conn: conn,
 	}
+
+	return c
 }
 
 // Serialize the data to JSON and send it to the client
@@ -36,4 +38,29 @@ func (c *connection) send(m morphData) error {
 	}
 
 	return nil
+}
+
+func (c *connection) receiver(s *Server) {
+	for {
+		data, _, err := wsutil.ReadClientData(c.conn)
+		if err != nil {
+			return
+		}
+
+		xy := struct {
+			X int `json:"x"`
+			Y int `json:"y"`
+			Id string `json:"id"`
+		}{}
+		err = json.Unmarshal(data, &xy)
+		if err != nil {
+			return
+		}
+
+		s.broadcast(morphData{
+			Type: "morph_data",
+			Id:   "cursor_" + xy.Id,
+			Html: fmt.Sprintf("<div id=\"cursor_%s\" class=\"cursor\" style=\"--x: %d; --y: %d;\"> </div>", xy.Id, xy.X, xy.Y),
+		})
+	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -105,7 +105,7 @@ func (s *Server) addConnection(c net.Conn) {
 		id := fmt.Sprint(conn.id)
 		conn.send(morphData{
 			Type: "connected",
-			Id : id,
+			Id:   id,
 		})
 		go s.broadcast(morphData{
 			Type: "morph_data",

--- a/templates/css/index.css
+++ b/templates/css/index.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+.cursor {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: red;
+  top: var(--y, 0);
+  left: var(--x, 0);
+}

--- a/templates/index.go.html
+++ b/templates/index.go.html
@@ -23,6 +23,7 @@
           </div>
     </div>
   </div>
+  <div id="cursors"></div>
 </body>
 
 <script type="module" src="public/index.js"></script>

--- a/templates/index.ts
+++ b/templates/index.ts
@@ -3,13 +3,36 @@ import morphdom from "morphdom";
 // connect to websocket
 const socket = new WebSocket("ws://localhost:8080/ws");
 
+// initilize the connection id
+let connectionId: string;
+
 socket.onopen = () => {
   console.log("Connected");
 };
+
+// message types
+enum MessageType {
+  MorphData = "morph_data",
+  Connected = "connected",
+}
 
 socket.onmessage = (event) => {
   const data = JSON.parse(event.data);
   const id = data.id;
   const html = data.html;
-  morphdom(document.getElementById(id) as Node, html);
+  const type = data.type as MessageType;
+  switch (type) {
+    case MessageType.MorphData:
+      morphdom(document.getElementById(id) as Node, html);
+      break;
+    case MessageType.Connected:
+      console.log("Connected: ", id);
+      connectionId = id;
+      break;
+  }
 };
+
+// send mouse position to the server
+window.onmousemove = (event: { clientX: any; clientY: any; }) => {
+  socket.send(JSON.stringify({ id: connectionId, x: event.clientX, y: event.clientY }));
+}


### PR DESCRIPTION
This adds a new feature that continually sends the cursor location from the client side to the server. The server then broadcasts to all clients an updated `div` with the new mouse positions included so that an indicator for each connected client will be rendered showing live real-time cursor location.

This is a bit messy right now but it works. It would be nice to make this a bit more modular so that it is a better example. Could also use some debouncing and nicer appearance.